### PR TITLE
Spacing fixes, fixed white background in TIPS section

### DIFF
--- a/Update/_mina_005.txt
+++ b/Update/_mina_005.txt
@@ -834,7 +834,7 @@ void main()
 		   NULL, "\"Sure.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 12, "ps3/s12/12/181100081", 256, TRUE);
 	OutputLine(NULL, "………どうして梨花が、必ず昭和５８年に殺されるか、ですね？」",
-		   NULL, "....You want to know why you're being murdered in 1983?\"", Line_Normal);
+		   NULL, ".... You want to know why you're being murdered in 1983?\"", Line_Normal);
 	ClearMessage();
 
 

--- a/Update/_mina_011_1.txt
+++ b/Update/_mina_011_1.txt
@@ -716,7 +716,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps2/01/180100525", 540, TRUE);
 	OutputLine(NULL, "まったく糞っ垂れな話だぜ。」",
-		   NULL, " It's total bullshit.\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, "It's total bullshit.\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f0953d>レナ</color>", NULL, "<color=#f0953d>Rena</color>", NULL, Line_ContinueAfterTyping); }

--- a/Update/_mina_013.txt
+++ b/Update/_mina_013.txt
@@ -3030,7 +3030,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#5a5e5e>亀田</color>", NULL, "<color=#5a5e5e>Kameda</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 23, "ps3/s12/23/182800005", 256, TRUE);
 	OutputLine(NULL, "　でもでも、",
-		   NULL, " But", Line_Continue);
+		   NULL, "But", Line_Continue);
 	// (backup) SetValidityOfInput( FALSE );
 	Wait( 3000 );
 	// (backup) SetValidityOfInput( TRUE );
@@ -4413,7 +4413,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f5e6d3>オタク</color>", NULL, "<color=#f5e6d3>Otaku</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 0, "ps3/s12/00/otag18001", 256, TRUE);
 	OutputLine(NULL, "「沙都子嬢救出作戦了解！！",
-		   NULL, " \"This is Operation Satoko!", Line_WaitForInput);
+		   NULL, "\"This is Operation Satoko!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 0, "ps3/s12/00/otag18002", 256, TRUE);
 	OutputLine(NULL, "　作戦開始は明日夕刻！",
 		   NULL, " Your mission starts tomorrow evening!", Line_WaitForInput);

--- a/Update/_mina_ep.txt
+++ b/Update/_mina_ep.txt
@@ -1216,13 +1216,13 @@ void main()
 		   NULL, "\"So we'll lose the trust of all our allies, huh.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 0, "ps2/00/282900020", 540, TRUE);
 	OutputLine(NULL, "……くそ。",
-		   NULL, "...Shit.", Line_WaitForInput);
+		   NULL, " ...Shit.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 0, "ps2/00/282900021", 540, TRUE);
 	OutputLine(NULL, "つまり雛見沢地区と周辺自治体の数十万人だけの問題では済まんということだな。",
 		   NULL, " So this isn't just the problem of the several hundred thousand people who live around the Hinamizawa area, is it...?", Line_WaitForInput);
 	ModPlayVoiceLS(4, 0, "ps2/00/282900022", 540, TRUE);
 	OutputLine(NULL, "…………しかし！！",
-		   NULL, ".........But!! ", GetGlobalFlag(GLinemodeSp));
+		   NULL, " .........But!! ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f5e6d3>官房長官</color>", NULL, "<color=#f5e6d3>Government Secretary</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 0, "ps2/00/282900023", 540, TRUE);
 	OutputLine(NULL, "　全てを闇に葬るための犠牲が二千人とは多過ぎる！」",

--- a/Update/_mina_tips_013.txt
+++ b/Update/_mina_tips_013.txt
@@ -210,4 +210,5 @@ void main()
 	DisableWindow();
 	Wait( 1000 );
 	DrawScene( "white", 7000 );
+	DrawScene( "black", 0 );
 }


### PR DESCRIPTION
* Fixed spacing issues in ADV mode (tested both ADV and NVL)
* Fixed white background leaking into TIPS section after viewing "This Fragment's End" tip (it should be black just like other tips):

![tips section background is white after watching latest tip](https://user-images.githubusercontent.com/3995549/97347555-03a55b80-189e-11eb-93c0-1be3d2755506.png)
